### PR TITLE
Rebuild on node changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,13 @@
     "heroku-debug-5.0.2": "file:test/heroku-debug/5.0.2",
     "heroku-debug-5.0.3": "file:test/heroku-debug/5.0.3",
     "heroku-hello-world-build": "0.0.0",
+    "heroku-kafka": "2.9.8",
+    "heroku-pg-extras": "1.0.11",
     "jest": "20.0.4",
     "mock-fs": "4.4.1",
     "nock": "9.0.13",
     "rimraf": "2.6.1",
+    "semver": "5.3.0",
     "uglify-js": "github:mishoo/UglifyJS2#73d6438773a40aa5aa06354781334af79a67e42d"
   },
   "engines": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -49,12 +49,8 @@ export default class Main {
     debug('autoupdating')
     await updater.autoupdate()
 
-    debug('loading plugins')
-    let plugins = new Plugins(out)
-    await plugins.load()
-
     try {
-      const migrator = new MigrateV5Plugins(plugins, this.config)
+      const migrator = new MigrateV5Plugins(out)
       await migrator.run()
     } catch (err) {
       out.warn('Error migrating v5 plugins')
@@ -65,6 +61,10 @@ export default class Main {
       debug('running help')
       this.cmd = await Help.run({argv: this.argv.slice(1), config: this.config, mock: this.mock})
     } else {
+      debug('loading plugins')
+      let plugins = new Plugins(out)
+      await plugins.load()
+
       debug('finding command')
       let Command = await plugins.findCommand(this.argv[1] || this.config.defaultCommand)
       if (!Command) return new NotFound(out, this.argv).run()

--- a/src/plugins/cache.js
+++ b/src/plugins/cache.js
@@ -129,15 +129,18 @@ export default class Cache {
     let plugins = []
     if (this.cache.node_version !== process.version) {
       let lock = new Lock(this.out)
+      let handled = true
 
       let downgrade = await lock.upgrade()
       for (let manager of managers) {
-        await manager.handleNodeVersionChange()
+        handled = await manager.handleNodeVersionChange() && handled
       }
       await downgrade()
 
-      this.cache.node_version = process.version
-      this.constructor.updated = true
+      if (handled) {
+        this.cache.node_version = process.version
+        this.constructor.updated = true
+      }
     }
 
     for (let manager of managers) {

--- a/src/plugins/cache.js
+++ b/src/plugins/cache.js
@@ -129,18 +129,15 @@ export default class Cache {
     let plugins = []
     if (this.cache.node_version !== process.version) {
       let lock = new Lock(this.out)
-      let handled = true
 
       let downgrade = await lock.upgrade()
       for (let manager of managers) {
-        handled = await manager.handleNodeVersionChange() && handled
+        await manager.handleNodeVersionChange()
       }
       await downgrade()
 
-      if (handled) {
-        this.cache.node_version = process.version
-        this.constructor.updated = true
-      }
+      this.cache.node_version = process.version
+      this.constructor.updated = true
     }
 
     for (let manager of managers) {

--- a/src/plugins/cache.js
+++ b/src/plugins/cache.js
@@ -7,6 +7,7 @@ import Plugin from './plugin'
 import {Manager, type PluginPath} from './manager'
 import path from 'path'
 import fs from 'fs-extra'
+import Lock from '../lock'
 
 export type CachedCommand = {
   id: string,
@@ -38,6 +39,7 @@ export type CachedPlugin = {
 
 type CacheData = {
   version: string,
+  node_version?: ?string,
   plugins: {[path: string]: CachedPlugin}
 }
 
@@ -52,17 +54,35 @@ export default class Cache {
     this.config = output.config
   }
 
+  initialize () {
+    this._cache = {
+      version: this.config.version,
+      plugins: {},
+      node_version: null
+    }
+  }
+
+  clear () {
+    this._cache = {
+      version: this.config.version,
+      plugins: {},
+      node_version: this._cache.node_version
+    }
+  }
+
   get file (): string { return path.join(this.config.cacheDir, 'plugins.json') }
   get cache (): CacheData {
     if (this._cache) return this._cache
-    let initial = {version: this.config.version, plugins: {}}
+
     try {
       this._cache = fs.readJSONSync(this.file)
     } catch (err) {
       if (err.code !== 'ENOENT') this.out.debug(err)
-      this._cache = initial
+      this.initialize()
     }
-    if (this._cache.version !== this.config.version) this._cache = initial
+    if (this._cache.version !== this.config.version) {
+      this.clear()
+    }
     return this._cache
   }
 
@@ -107,6 +127,18 @@ export default class Cache {
 
   async fetchManagers (...managers: Manager[]): Promise<Plugin[]> {
     let plugins = []
+    if (this.cache.node_version !== process.version) {
+      let lock = new Lock(this.out)
+
+      let downgrade = await lock.upgrade()
+      for (let manager of managers) {
+        await manager.handleNodeVersionChange()
+      }
+      await downgrade()
+
+      this.cache.node_version = process.version
+      this.constructor.updated = true
+    }
 
     for (let manager of managers) {
       let paths = await manager.list()

--- a/src/plugins/cache.test.js
+++ b/src/plugins/cache.test.js
@@ -21,13 +21,18 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
+test('new Cache(output)', () => {
+  let cache = new Cache(output)
+  expect(cache.cache.node_version).toBeNull()
+})
+
 test('updatePlugin', () => {
   let cache = new Cache(output)
   cache.updatePlugin('myplugin', myplugin)
   cache.save()
   expect(fs.writeJSONSync).toBeCalledWith(
     path.join(config.cacheDir, 'plugins.json'),
-    {plugins: {myplugin}, version: config.version}
+    {node_version: null, plugins: {myplugin}, version: config.version}
   )
 })
 
@@ -55,5 +60,24 @@ describe('with existing file', () => {
       path.join(config.cacheDir, 'plugins.json'),
       {plugins: {}, version: config.version}
     )
+  })
+})
+
+describe('with existing for a previous version', () => {
+  beforeEach(() => {
+    fs.__files({
+      [config.cacheDir]: {
+        'plugins.json': {
+          version: '1.0.0',
+          plugins: {myplugin},
+          node_version: '2.0.0'
+        }
+      }
+    })
+  })
+
+  test('does not clear node_version', () => {
+    let cache = new Cache(output)
+    expect(cache.cache).toEqual({node_version: '2.0.0', plugins: {}, version: config.version})
   })
 })

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -161,9 +161,10 @@ export default class Plugins {
 
   async addLinkedPlugin (p: string) {
     let downgrade = await this.lock.upgrade()
-    let name = this.linked.checkLinked(p)
 
     await this.load()
+    let name = this.linked.checkLinked(p)
+
     if (this.plugins.find(p => p.type === 'user' && p.name === name)) {
       throw new Error(`${name} is already installed.\nUninstall with ${this.out.color.cmd(this.config.bin + ' plugins:uninstall ' + name)}`)
     }

--- a/src/plugins/linked.js
+++ b/src/plugins/linked.js
@@ -168,10 +168,17 @@ export default class LinkedPlugins extends Manager {
     this.out.action.stop()
   }
 
-  async handleNodeVersionChange () {
+  async handleNodeVersionChange (): Promise<boolean> {
+    let handled = true
     for (let p of this._data.plugins) {
-      await this._install(p, true)
+      try {
+        await this._install(p, true)
+      } catch (err) {
+        this.out.warn(err)
+        handled = false
+      }
     }
+    return handled
   }
 
   checkLinked (p: string) {

--- a/src/plugins/linked.js
+++ b/src/plugins/linked.js
@@ -159,13 +159,19 @@ export default class LinkedPlugins extends Manager {
       .find(f => f.stats.mtime > this._data.updated_at)
   }
 
-  async _install (p: string) {
-    if (!this._needsInstall(p)) return
+  async _install (p: string, force: boolean = false) {
+    if (!force && !this._needsInstall(p)) return
     if (!this.config.debug) this.out.action.start(`Installing dependencies for ${p}`)
     let yarn = new Yarn(this.out, p)
     await yarn.exec()
     touch(path.join(p, 'node_modules'))
     this.out.action.stop()
+  }
+
+  async handleNodeVersionChange () {
+    for (let p of this._data.plugins) {
+      await this._install(p, true)
+    }
   }
 
   checkLinked (p: string) {

--- a/src/plugins/linked.js
+++ b/src/plugins/linked.js
@@ -168,17 +168,14 @@ export default class LinkedPlugins extends Manager {
     this.out.action.stop()
   }
 
-  async handleNodeVersionChange (): Promise<boolean> {
-    let handled = true
+  async handleNodeVersionChange () {
     for (let p of this._data.plugins) {
       try {
         await this._install(p, true)
       } catch (err) {
         this.out.warn(err)
-        handled = false
       }
     }
-    return handled
   }
 
   checkLinked (p: string) {

--- a/src/plugins/linked.test.js
+++ b/src/plugins/linked.test.js
@@ -183,5 +183,5 @@ test('plugins should be loaded when things cannot be rebuilt', async () => {
   }
 
   let pluginsJson = fs.readJSONSync(pluginsJsonPath)
-  expect(pluginsJson['node_version']).toBeNull()
+  expect(pluginsJson['node_version']).toEqual(process.version)
 })

--- a/src/plugins/linked.test.js
+++ b/src/plugins/linked.test.js
@@ -1,8 +1,8 @@
 // @flow
 
-import {buildConfig} from 'cli-engine-config'
-import Output from 'cli-engine-command/lib/output'
 import Plugins from '../plugins'
+import {tmpDirs} from '../../test/helpers'
+import CLI from '../cli'
 import tmp from 'tmp'
 
 const path = require('path')
@@ -10,52 +10,42 @@ const fs = require('fs-extra')
 
 jest.unmock('fs-extra')
 
-let testDir
-let cacheDir
-let dataDir
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000
+
 let pluginsJsonPath
-let linkPath
 
+function copyLink (link) {
+  let testDir = path.join(path.dirname(__filename), '..', '..', 'test')
+  let linkPathSrc = path.normalize(path.join(testDir, 'links', link))
+  let tmpDir = tmp.dirSync().name
+  fs.copySync(linkPathSrc, tmpDir)
+  return tmpDir
+}
+
+let tmpDir
 beforeEach(async () => {
-  testDir = path.join(path.dirname(__filename), '..', '..', 'test')
-
-  dataDir = tmp.dirSync().name
-  cacheDir = tmp.dirSync().name
-
-  let linkPathSrc = path.normalize(path.join(testDir, 'links', 'test-foo'))
-
-  linkPath = tmp.dirSync().name
-  fs.copySync(linkPathSrc, linkPath)
-
-  pluginsJsonPath = path.join(cacheDir, 'plugins.json')
+  tmpDir = await tmpDirs()
+  pluginsJsonPath = path.join(tmpDir.cacheDir, 'plugins.json')
 })
 
 afterEach(() => {
-  fs.removeSync(cacheDir)
-  fs.removeSync(dataDir)
-  fs.removeSync(linkPath)
+  tmpDir.clean()
 })
 
 test('linked plugin should be cached', async () => {
-  let root = path.join(testDir, 'roots', 'test-foo')
-  let pjson = fs.readJSONSync(path.join(root, 'package.json'))
-  let config = buildConfig({root, cacheDir, dataDir, pjson})
-  let output = new Output({config, mock: true})
-  let plugins = new Plugins(output)
-  await plugins.load()
-
-  let FooCore = await plugins.findCommand('foo')
+  let FooCore = await tmpDir.plugins.findCommand('foo')
   expect(FooCore).toHaveProperty('description', 'core')
 
-  let corePath = path.normalize(path.join(root, 'node_modules', 'test-foo'))
+  let corePath = path.normalize(path.join(tmpDir.root, 'node_modules', 'test-foo'))
 
-  await plugins.addLinkedPlugin(linkPath)
+  let linkPath = copyLink('test-foo')
+  await tmpDir.plugins.addLinkedPlugin(linkPath)
 
   let pluginsJson = fs.readJSONSync(pluginsJsonPath)
   expect(pluginsJson['plugins'][linkPath]).toBeUndefined()
   expect(pluginsJson['plugins'][corePath]).toBeDefined()
 
-  plugins = new Plugins(output)
+  let plugins = new Plugins(tmpDir.output)
   await plugins.load()
   let FooLinked = await plugins.findCommand('foo')
   expect(FooLinked).toHaveProperty('description', 'link')
@@ -90,29 +80,23 @@ test('linked plugin should be cached', async () => {
   expect(pluginsJson['plugins'][linkPath]).toBeUndefined()
   expect(pluginsJson['plugins'][corePath]).toBeDefined()
 
-  plugins = new Plugins(output)
+  plugins = new Plugins(tmpDir.output)
   await plugins.load()
   FooCore = await plugins.findCommand('foo')
   expect(FooCore).toHaveProperty('description', 'core')
 })
 
 test('linked plugin prepare should clear cache', async () => {
-  let root = path.join(testDir, 'roots', 'test-foo')
-  let pjson = fs.readJSONSync(path.join(root, 'package.json'))
-  let config = buildConfig({root, cacheDir, dataDir, pjson})
-  let output = new Output({config, mock: true})
-  let plugins = new Plugins(output)
-  await plugins.load()
+  let corePath = path.normalize(path.join(tmpDir.root, 'node_modules', 'test-foo'))
 
-  let corePath = path.normalize(path.join(root, 'node_modules', 'test-foo'))
-
-  await plugins.addLinkedPlugin(linkPath)
+  let linkPath = copyLink('test-foo')
+  await tmpDir.plugins.addLinkedPlugin(linkPath)
 
   let pluginsJson = fs.readJSONSync(pluginsJsonPath)
   expect(pluginsJson['plugins'][linkPath]).toBeUndefined()
   expect(pluginsJson['plugins'][corePath]).toBeDefined()
 
-  plugins = new Plugins(output)
+  let plugins = new Plugins(tmpDir.output)
   await plugins.load()
   let FooLinked = await plugins.findCommand('foo')
   expect(FooLinked).toHaveProperty('description', 'link')
@@ -151,4 +135,30 @@ test('linked plugin prepare should clear cache', async () => {
   pluginsJson = fs.readJSONSync(pluginsJsonPath)
   expect(pluginsJson['plugins'][linkPath]).toBeUndefined()
   expect(pluginsJson['plugins'][corePath]).toBeDefined()
+})
+
+test('plugins should be reloaded when node_version changed', async () => {
+  let linkPath = copyLink('1_hello_world')
+  await tmpDir.plugins.addLinkedPlugin(linkPath)
+
+  let pluginsJsonPath = path.join(tmpDir.cacheDir, 'plugins.json')
+
+  // emulate an old version of node
+  let pluginsJson = fs.readJSONSync(pluginsJsonPath)
+  pluginsJson['node_version'] = '1.0.0'
+  fs.writeJSONSync(pluginsJsonPath, pluginsJson)
+
+  // attempt to emulate a build mismatch by removing build from snappy
+  let buildDir = path.join(linkPath, 'build')
+  fs.removeSync(buildDir)
+
+  let cli = new CLI({argv: ['cli', 'hello'], mock: true, config: tmpDir.config})
+  try {
+    await cli.run()
+  } catch (err) {
+    if (err.code !== 0) throw err
+  }
+
+  pluginsJson = fs.readJSONSync(pluginsJsonPath)
+  expect(pluginsJson['node_version']).toEqual(process.version)
 })

--- a/src/plugins/manager.js
+++ b/src/plugins/manager.js
@@ -156,4 +156,8 @@ export class Manager {
   async list (): Promise<PluginPath[]> {
     throw new Error('abstract method Manager.list')
   }
+
+  async handleNodeVersionChange () {
+    // user and linked will override
+  }
 }

--- a/src/plugins/manager.js
+++ b/src/plugins/manager.js
@@ -157,7 +157,8 @@ export class Manager {
     throw new Error('abstract method Manager.list')
   }
 
-  async handleNodeVersionChange () {
+  async handleNodeVersionChange (): Promise<boolean> {
     // user and linked will override
+    return true
   }
 }

--- a/src/plugins/manager.js
+++ b/src/plugins/manager.js
@@ -157,8 +157,7 @@ export class Manager {
     throw new Error('abstract method Manager.list')
   }
 
-  async handleNodeVersionChange (): Promise<boolean> {
+  async handleNodeVersionChange () {
     // user and linked will override
-    return true
   }
 }

--- a/src/plugins/migrator.js
+++ b/src/plugins/migrator.js
@@ -1,7 +1,7 @@
 // @flow
 
 import Output from 'cli-engine-command/lib/output'
-import {PluginsBase} from '.'
+import Plugins from '.'
 import UserPlugins from './user'
 import path from 'path'
 import fs from 'fs-extra'
@@ -9,12 +9,12 @@ import fs from 'fs-extra'
 const debug = require('debug')('cli-engine:migrator')
 
 export default class {
-  plugins: PluginsBase
+  plugins: Plugins
   userPlugins: UserPlugins
   out: Output
 
   constructor (out: Output) {
-    this.plugins = new PluginsBase(out)
+    this.plugins = new Plugins(out, {migrating: true})
     this.userPlugins = this.plugins.user
     this.out = out
   }

--- a/src/plugins/migrator.js
+++ b/src/plugins/migrator.js
@@ -1,29 +1,46 @@
 // @flow
 
 import Output from 'cli-engine-command/lib/output'
-import Plugins from '.'
 import UserPlugins from './user'
+import LinkedPlugins from './linked'
+import PluginCache from './cache'
 import path from 'path'
 import fs from 'fs-extra'
+import Lock from '../lock'
 
 const debug = require('debug')('cli-engine:migrator')
 
 export default class {
-  plugins: Plugins
   userPlugins: UserPlugins
+  linkedPlugins: LinkedPlugins
   out: Output
+  lock: Lock
 
   constructor (out: Output) {
-    this.plugins = new Plugins(out, {migrating: true})
-    this.userPlugins = this.plugins.user
+    let cache = new PluginCache(out)
+    this.userPlugins = new UserPlugins({out, config: out.config, cache})
+    this.linkedPlugins = new LinkedPlugins({out, config: out.config, cache})
     this.out = out
+    this.lock = new Lock(this.out)
   }
 
   async run () {
+    // short circuit quickly without having to aquire the writer lock
     if (fs.existsSync(this.userPlugins.userPluginsPJSONPath)) return
     if (!fs.existsSync(path.join(this.userPlugins.userPluginsDir, 'plugins.json'))) return
+
     let pljson = await this._readPluginsJSON()
     if (!pljson) return false
+
+    let downgrade = await this.lock.upgrade()
+    await this._run(pljson)
+    await downgrade()
+  }
+
+  async _run (pljson: any) {
+    // prevent two parallel migrations from happening in case of a race
+    if (fs.existsSync(this.userPlugins.userPluginsPJSONPath)) return
+
     debug('has existing plugins')
     this.out.action.start('Migrating Heroku CLI v5 plugins')
     debug('removing existing node_modules')
@@ -49,7 +66,7 @@ export default class {
         await this._reinstallViaSymlink(name)
       } else {
         if (tag === '') tag = 'latest'
-        await this.plugins.install(name)
+        await this.userPlugins.install(name)
       }
     } catch (err) {
       this.out.warn(err)
@@ -59,6 +76,6 @@ export default class {
   async _reinstallViaSymlink (name: string) {
     debug(`Installing via symlink: ${name}`)
     let pluginPath = fs.realpathSync(this.userPlugins.userPluginPath(name))
-    await this.plugins.addLinkedPlugin(pluginPath)
+    await this.linkedPlugins.add(pluginPath)
   }
 }

--- a/src/plugins/migrator.js
+++ b/src/plugins/migrator.js
@@ -1,8 +1,7 @@
 // @flow
 
-import {type Config} from 'cli-engine-config'
 import Output from 'cli-engine-command/lib/output'
-import Plugins from '.'
+import {PluginsBase} from '.'
 import UserPlugins from './user'
 import path from 'path'
 import fs from 'fs-extra'
@@ -10,16 +9,14 @@ import fs from 'fs-extra'
 const debug = require('debug')('cli-engine:migrator')
 
 export default class {
-  plugins: Plugins
+  plugins: PluginsBase
   userPlugins: UserPlugins
-  config: Config
   out: Output
 
-  constructor (plugins: Plugins, config: Config) {
-    this.plugins = plugins
-    this.config = config
-    this.userPlugins = plugins.user
-    this.out = plugins.out
+  constructor (out: Output) {
+    this.plugins = new PluginsBase(out)
+    this.userPlugins = this.plugins.user
+    this.out = out
   }
 
   async run () {
@@ -34,8 +31,6 @@ export default class {
       debug(`installing ${p.name}`)
       await this._installPlugin(p.name, p.tag)
     }
-    this.plugins.loaded = false
-    await this.plugins.load()
     this.out.action.stop()
   }
 

--- a/src/plugins/migrator.js
+++ b/src/plugins/migrator.js
@@ -34,7 +34,6 @@ export default class {
       debug(`installing ${p.name}`)
       await this._installPlugin(p.name, p.tag)
     }
-    await this.userPlugins.yarn.exec(['install', '--force'])
     this.plugins.loaded = false
     await this.plugins.load()
     this.out.action.stop()

--- a/src/plugins/migrator.test.js
+++ b/src/plugins/migrator.test.js
@@ -46,8 +46,6 @@ test('plugins should be reloaded if migrated', async () => {
   } catch (err) {
     if (err.code !== 0) throw err
   }
-
-  expect(mockYarnExec).toBeCalledWith(['install', '--force'])
 })
 
 test('linked plugins should be migrated', async () => {

--- a/src/plugins/user.js
+++ b/src/plugins/user.js
@@ -124,13 +124,11 @@ export default class UserPlugins extends Manager {
     }
   }
 
-  async handleNodeVersionChange (): Promise<boolean> {
+  async handleNodeVersionChange () {
     try {
       await this.installForce()
-      return true
     } catch (err) {
       this.out.warn(err)
-      return false
     }
   }
 

--- a/src/plugins/user.js
+++ b/src/plugins/user.js
@@ -17,18 +17,18 @@ type PJSON = {
 }
 
 class UserPluginPath extends PluginPath {
-  yarn: Yarn
+  userPlugins: UserPlugins
   repairAttempted = false
 
-  constructor ({output, type, path, tag, yarn}: {
+  constructor ({output, type, path, tag, userPlugins}: {
     output: Output,
       type: PluginType,
       tag: string,
       path: string,
-      yarn: Yarn
+      userPlugins: UserPlugins
   }) {
     super({output, type, path, tag})
-    this.yarn = yarn
+    this.userPlugins = userPlugins
   }
 
   async repair (err: Error): Promise<boolean> {
@@ -37,16 +37,37 @@ class UserPluginPath extends PluginPath {
     this.out.warn(err)
     this.out.action.start(`Repairing plugin ${this.path}`)
     this.repairAttempted = true
-    await this.yarn.exec(['install', '--force'])
+
+    await this.userPlugins.installForce()
     this.out.action.stop()
     return true
   }
 }
 
 export default class UserPlugins extends Manager {
+  hardcodedDepFixes: Object
+
   constructor ({out, config, cache}: {out: Output, config: Config, cache: Cache}) {
     super({out, config, cache})
     this.yarn = new Yarn(this.out, this.userPluginsDir)
+
+    /**
+     * There is a bug with snappy & node-gyp & semver that causes issues when
+     * we rebuild.  What happens is that semver is downgraded from 5.3.0 to
+     * 4.3.2 which has a bug in it that causes node-gyp to fail
+     *
+     * I was going to try and make this an add to package.json to save some
+     * time but that causes 4.3.2 to install into node-gyp/node_modules for
+     * reasons I do not understand but `add` does the right thing
+     *
+     * I set version to ~5.3.0 to match the current dependency from node-gyp
+     * under the assumption that it is the most likely to work properly
+     *
+     * https://github.com/nodejs/node-gyp/blob/75cfae290fee1791a23fa68820ae5dd841e93e14/package.json#L34
+     */
+    this.hardcodedDepFixes = {
+      semver: '~5.3.0'
+    }
   }
 
   yarn: Yarn
@@ -58,9 +79,13 @@ export default class UserPlugins extends Manager {
   async list (): Promise<PluginPath[]> {
     try {
       const pjson = this.userPluginsPJSON
-      return entries(pjson.dependencies || {}).map(([name, tag]) => {
-        return new UserPluginPath({output: this.out, type: 'user', path: this.userPluginPath(name), tag: tag, yarn: this.yarn})
-      })
+      return entries(pjson.dependencies || {})
+        .filter(([name, tag]) => {
+          return !this.hardcodedDepFixes[name]
+        })
+        .map(([name, tag]) => {
+          return new UserPluginPath({output: this.out, type: 'user', path: this.userPluginPath(name), tag: tag, userPlugins: this})
+        })
     } catch (err) {
       this.out.warn(err, 'error loading user plugins')
       return []
@@ -87,9 +112,25 @@ export default class UserPlugins extends Manager {
     if (!fs.existsSync(yarnrc)) fs.writeFileSync(yarnrc, 'registry "https://cli-npm.heroku.com/"')
   }
 
-  async handleNodeVersionChange () {
+  async installForce () {
     if (fs.existsSync(path.join(this.userPluginsDir, 'node_modules'))) {
+      let dependencies = this.userPluginsPJSON['dependencies'] || {}
+      for (let mod in this.hardcodedDepFixes) {
+        if (!dependencies[mod]) {
+          await this.yarn.exec(['add', `${mod}@${this.hardcodedDepFixes[mod]}`])
+        }
+      }
       await this.yarn.exec(['install', '--force'])
+    }
+  }
+
+  async handleNodeVersionChange (): Promise<boolean> {
+    try {
+      await this.installForce()
+      return true
+    } catch (err) {
+      this.out.warn(err)
+      return false
     }
   }
 

--- a/src/plugins/user.js
+++ b/src/plugins/user.js
@@ -87,6 +87,12 @@ export default class UserPlugins extends Manager {
     if (!fs.existsSync(yarnrc)) fs.writeFileSync(yarnrc, 'registry "https://cli-npm.heroku.com/"')
   }
 
+  async handleNodeVersionChange () {
+    if (fs.existsSync(path.join(this.userPluginsDir, 'node_modules'))) {
+      await this.yarn.exec(['install', '--force'])
+    }
+  }
+
   async install (name: string, tag: string = 'latest') {
     await this.setupUserPlugins()
     this.addPackageToPJSON(name, tag)

--- a/src/plugins/user.test.js
+++ b/src/plugins/user.test.js
@@ -2,6 +2,7 @@
 
 import Plugins from '../plugins'
 import {tmpDirs} from '../../test/helpers'
+import CLI from '../cli'
 
 const path = require('path')
 const fs = require('fs-extra')
@@ -55,4 +56,64 @@ test('user plugin should be cached', async () => {
 
   pluginsJson = fs.readJSONSync(pluginsJsonPath)
   expect(pluginsJson['plugins'][userPath]).toBeUndefined()
+})
+
+test('plugins should be reloaded when node_version null', async () => {
+  await tmpDir.plugins.install('heroku-hello-world-build', '0.0.0')
+
+  let dataDir = tmpDir.dataDir
+  let plugins = path.join(dataDir, 'plugins')
+
+  // remove the cache that tmpDirs creates
+  let pluginsJsonPath = path.join(tmpDir.cacheDir, 'plugins.json')
+  fs.removeSync(pluginsJsonPath)
+
+  fs.removeSync(path.join(plugins, 'package.json'))
+  fs.removeSync(path.join(plugins, 'yarn.lock'))
+
+  // attempt to emulate a build mismatch by removing build from snappy
+  let buildDir = path.join(plugins, 'node_modules', 'heroku-hello-world-build', 'build')
+  fs.removeSync(buildDir)
+
+  // drop in v5 plugins.json
+  let json = [{name: 'heroku-hello-world-build'}]
+  fs.writeJSONSync(path.join(dataDir, 'plugins', 'plugins.json'), json)
+
+  let cli = new CLI({argv: ['cli', 'hello'], mock: true, config: tmpDir.config})
+  try {
+    await cli.run()
+  } catch (err) {
+    if (err.code !== 0) throw err
+  }
+
+  let pluginsJson = fs.readJSONSync(pluginsJsonPath)
+  expect(pluginsJson['node_version']).toEqual(process.version)
+})
+
+test('plugins should be reloaded when node_version changed', async () => {
+  await tmpDir.plugins.install('heroku-hello-world-build', '0.0.0')
+
+  let dataDir = tmpDir.dataDir
+  let plugins = path.join(dataDir, 'plugins')
+
+  let pluginsJsonPath = path.join(tmpDir.cacheDir, 'plugins.json')
+
+  // emulate an old version of node
+  let pluginsJson = fs.readJSONSync(pluginsJsonPath)
+  pluginsJson['node_version'] = '1.0.0'
+  fs.writeJSONSync(pluginsJsonPath, pluginsJson)
+
+  // attempt to emulate a build mismatch by removing build from snappy
+  let buildDir = path.join(plugins, 'node_modules', 'heroku-hello-world-build', 'build')
+  fs.removeSync(buildDir)
+
+  let cli = new CLI({argv: ['cli', 'hello'], mock: true, config: tmpDir.config})
+  try {
+    await cli.run()
+  } catch (err) {
+    if (err.code !== 0) throw err
+  }
+
+  pluginsJson = fs.readJSONSync(pluginsJsonPath)
+  expect(pluginsJson['node_version']).toEqual(process.version)
 })

--- a/src/plugins/user.test.js
+++ b/src/plugins/user.test.js
@@ -10,7 +10,7 @@ const fs = require('fs-extra')
 
 jest.unmock('fs-extra')
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000
 
 let tmpDir
 beforeEach(async () => {
@@ -120,6 +120,8 @@ test('plugins should be reloaded when node_version changed', async () => {
 })
 
 test('problematic version of semver should be overwritten', async () => {
+  if (tmpDir.config.windows) return // cannot remove snappy dir when loaded
+
   await tmpDir.plugins.install('heroku-kafka', '2.9.8')
   await tmpDir.plugins.install('heroku-pg-extras', '1.0.11')
 
@@ -146,6 +148,8 @@ test('problematic version of semver should be overwritten', async () => {
 })
 
 test('problematic version of semver from previous release should be overwritten', async () => {
+  if (tmpDir.config.windows) return // cannot remove snappy dir when loaded
+
   await tmpDir.plugins.install('heroku-kafka', '2.9.8')
   await tmpDir.plugins.install('heroku-pg-extras', '1.0.11')
 
@@ -174,6 +178,8 @@ test('problematic version of semver from previous release should be overwritten'
 })
 
 test('plugins should be loaded when things cannot be rebuilt', async () => {
+  if (tmpDir.config.windows) return // cannot remove package.json when loaded
+
   await tmpDir.plugins.install('heroku-hello-world-build', '0.0.0')
 
   let dataDir = tmpDir.dataDir

--- a/src/plugins/user.test.js
+++ b/src/plugins/user.test.js
@@ -127,6 +127,9 @@ test('problematic version of semver should be overwritten', async () => {
   let pluginsJsonPath = path.join(tmpDir.cacheDir, 'plugins.json')
   fs.removeSync(pluginsJsonPath)
 
+  let snappyBuild = path.join(tmpDir.dataDir, 'plugins', 'node_modules', 'snappy', 'build')
+  fs.removeSync(snappyBuild)
+
   let plugins = new Plugins(tmpDir.output)
   await plugins.load()
 
@@ -138,6 +141,8 @@ test('problematic version of semver should be overwritten', async () => {
 
   let pluginsJson = fs.readJSONSync(pluginsJsonPath)
   expect(pluginsJson['node_version']).toEqual(process.version)
+
+  expect(fs.existsSync(snappyBuild)).toEqual(true)
 })
 
 test('problematic version of semver from previous release should be overwritten', async () => {
@@ -148,18 +153,24 @@ test('problematic version of semver from previous release should be overwritten'
   let pluginsJsonPath = path.join(tmpDir.cacheDir, 'plugins.json')
   fs.removeSync(pluginsJsonPath)
 
-  let yarn = new Yarn(tmpDir.output, tmpDir.plugins.user.userPluginsDir)
+  let pluginsDir = tmpDir.plugins.user.userPluginsDir
+  let yarn = new Yarn(tmpDir.output, pluginsDir)
 
   try {
     // put our installation in the same state as the failed updates
     await yarn.exec(['install', '--force'])
   } catch (err) {}
 
+  let snappyBuild = path.join(pluginsDir, 'node_modules', 'snappy', 'build')
+  fs.removeSync(snappyBuild)
+
   let plugins = new Plugins(tmpDir.output)
   await plugins.load()
 
   let pluginsJson = fs.readJSONSync(pluginsJsonPath)
   expect(pluginsJson['node_version']).toEqual(process.version)
+
+  expect(fs.existsSync(snappyBuild)).toEqual(true)
 })
 
 test('plugins should be loaded when things cannot be rebuilt', async () => {
@@ -184,5 +195,5 @@ test('plugins should be loaded when things cannot be rebuilt', async () => {
   }
 
   let pluginsJson = fs.readJSONSync(pluginsJsonPath)
-  expect(pluginsJson['node_version']).toBeNull()
+  expect(pluginsJson['node_version']).toEqual(process.version)
 })

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -18,10 +18,11 @@ export async function tmpDirs (cfg: any = {}) {
   let tmpDir = path.resolve(path.join(__dirname, '..', 'tmp'))
   fs.mkdirsSync(tmpDir)
 
-  let template = path.join(tmpDir, 'tmp-XXXXXX')
+  let dataTemplate = path.join(tmpDir, 'tmp-data-XXXXXX')
+  let cacheTemplate = path.join(tmpDir, 'tmp-cache-XXXXXX')
 
-  let dataDir = tmp.dirSync({template}).name
-  let cacheDir = tmp.dirSync({template}).name
+  let dataDir = tmp.dirSync({template: dataTemplate}).name
+  let cacheDir = tmp.dirSync({template: cacheTemplate}).name
 
   fs.mkdirs(path.join(dataDir, 'plugins'))
 
@@ -41,5 +42,5 @@ export async function tmpDirs (cfg: any = {}) {
     }
   }
 
-  return { clean, plugins, output, config, cacheDir, dataDir }
+  return { clean, plugins, output, config, cacheDir, dataDir, root }
 }

--- a/test/links/1_hello_world/binding.gyp
+++ b/test/links/1_hello_world/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "hello",
+      "sources": [ "hello.cc" ]
+    }
+  ]
+}

--- a/test/links/1_hello_world/hello.cc
+++ b/test/links/1_hello_world/hello.cc
@@ -1,0 +1,18 @@
+#include <node.h>
+#include <v8.h>
+
+using namespace v8;
+
+void Method(const v8::FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
+  args.GetReturnValue().Set(String::NewFromUtf8(isolate, "world"));
+}
+
+void Init(Handle<Object> exports) {
+  Isolate* isolate = Isolate::GetCurrent();
+  exports->Set(String::NewFromUtf8(isolate, "hello"),
+      FunctionTemplate::New(isolate, Method)->GetFunction());
+}
+
+NODE_MODULE(hello, Init)

--- a/test/links/1_hello_world/hello.js
+++ b/test/links/1_hello_world/hello.js
@@ -1,0 +1,11 @@
+module.exports.topic = {name: 'hello'}
+
+module.exports = {
+  commands: [{
+    topic: 'hello',
+    run: function (context) {
+      var addon = require('bindings')('hello')
+      addon.hello()
+    }
+  }]
+}

--- a/test/links/1_hello_world/package.json
+++ b/test/links/1_hello_world/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "hello_world",
+  "version": "0.0.0",
+  "description": "Node.js Addons Example #1",
+  "main": "hello.js",
+  "private": true,
+  "scripts": {
+    "test": "node hello.js"
+  },
+  "gypfile": true,
+  "dependencies": {
+    "bindings": "~1.2.1"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,6 +90,10 @@ anymatch@^1.3.0:
     arrify "^1.0.0"
     micromatch "^2.1.5"
 
+ap@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ap/-/ap-0.2.0.tgz#ae0942600b29912f0d2b14ec60c45e8f330b6110"
+
 append-transform@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
@@ -127,6 +131,13 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 
+array-index@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-index/-/array-index-1.0.0.tgz#ec56a749ee103e4e08c790b9c353df16055b97f9"
+  dependencies:
+    debug "^2.2.0"
+    es6-symbol "^3.0.2"
+
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -145,7 +156,7 @@ arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-asn1@~0.2.3:
+asn1@~0.2.0, asn1@~0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86"
 
@@ -432,6 +443,14 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bin-protocol@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/bin-protocol/-/bin-protocol-3.0.3.tgz#010e53caed26c2b6e8e3b6a33cbbfe484e65ca1e"
+  dependencies:
+    lodash "^4.1.0"
+    long "^3.0.3"
+    protocol-buffers-schema "^3.0.0"
+
 binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
@@ -443,7 +462,7 @@ binary-extensions@^1.0.0:
     buffers "~0.1.1"
     chainsaw "~0.1.0"
 
-bindings@~1.2.1:
+bindings@1.2.1, bindings@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.2.1.tgz#14ad6113812d2d37d72e67b4cacb4bb726505f11"
 
@@ -458,6 +477,10 @@ block-stream@*:
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
   dependencies:
     inherits "~2.0.0"
+
+bluebird@^3.3.3:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
 boom@2.x.x:
   version "2.10.1"
@@ -498,6 +521,14 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-crc32@^0.2.5:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+
+buffer-writer@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-1.0.1.tgz#22a936901e3029afcd7547eb4487ceb697a3bf08"
+
 buffers@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
@@ -509,6 +540,10 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.1:
 byline@5.x:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
+
+bytes@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -688,6 +723,10 @@ cliui@^3.0.3, cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+co-wait@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/co-wait/-/co-wait-0.0.0.tgz#c22372032218edbf6ed915e433546c21e445628b"
+
 co@4.6.0, co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -738,6 +777,10 @@ connected-domain@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/connected-domain/-/connected-domain-1.0.0.tgz#bfe77238c74be453a79f0cb6058deeb4f2358e93"
 
+connection-parse@0.0.x:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/connection-parse/-/connection-parse-0.0.7.tgz#18e7318aab06a699267372b10c5226d25a1c9a69"
+
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
@@ -768,6 +811,13 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
+cross-spawn-async@^2.1.1:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
+  dependencies:
+    lru-cache "^4.0.0"
+    which "^1.2.8"
+
 crypt@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
@@ -788,6 +838,12 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
+d@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
+  dependencies:
+    es5-ext "^0.10.9"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -800,7 +856,13 @@ debug@2.2.0:
   dependencies:
     ms "0.7.1"
 
-debug@2.x, debug@^2.1.1, debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
+debug@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
+  dependencies:
+    ms "0.7.2"
+
+debug@2.6.8, debug@2.x, debug@^2.1.1, debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -909,6 +971,28 @@ error-ex@^1.2.0:
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
     is-arrayish "^0.2.1"
+
+es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
+  version "0.10.23"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.23.tgz#7578b51be974207a5487821b56538c224e4e7b38"
+  dependencies:
+    es6-iterator "2"
+    es6-symbol "~3.1"
+
+es6-iterator@2:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.1.tgz#8e319c9f0453bf575d374940a655920e59ca5512"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-symbol "^3.1"
+
+es6-symbol@^3.0.2, es6-symbol@^3.1, es6-symbol@~3.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -1084,6 +1168,17 @@ exec-sh@^0.2.0:
   dependencies:
     merge "^1.1.3"
 
+execa@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.4.0.tgz#4eb6467a36a095fabb2970ff9d5e3fb7bce6ebc3"
+  dependencies:
+    cross-spawn-async "^2.1.1"
+    is-stream "^1.1.0"
+    npm-run-path "^1.0.0"
+    object-assign "^4.0.1"
+    path-key "^1.0.0"
+    strip-eof "^1.0.0"
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -1168,6 +1263,10 @@ fileset@^2.0.2:
   dependencies:
     glob "^7.0.3"
     minimatch "^3.0.3"
+
+filesize@3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.4.tgz#742fc7fb6aef4ee3878682600c22f840731e1fda"
 
 filesize@^3.5.10:
   version "3.5.10"
@@ -1330,6 +1429,20 @@ function-bind@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
+gauge@~2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.6.0.tgz#d35301ad18e96902b4751dcbbe40f4218b942a46"
+  dependencies:
+    aproba "^1.0.3"
+    console-control-strings "^1.0.0"
+    has-color "^0.1.7"
+    has-unicode "^2.0.0"
+    object-assign "^4.1.0"
+    signal-exit "^3.0.0"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wide-align "^1.1.0"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -1352,6 +1465,10 @@ generate-object-property@^1.1.0:
   resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
   dependencies:
     is-property "^1.0.0"
+
+generic-pool@2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-2.4.3.tgz#780c36f69dfad05a5a045dd37be7adca11a4f6ff"
 
 get-caller-file@^1.0.1:
   version "1.0.2"
@@ -1491,6 +1608,10 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-color@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
+
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
@@ -1505,6 +1626,13 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
+hashring@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/hashring/-/hashring-3.2.0.tgz#fda4efde8aa22cdb97fb1d2a65e88401e1c144ce"
+  dependencies:
+    connection-parse "0.0.x"
+    simple-lru-cache "0.0.x"
+
 hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
@@ -1513,6 +1641,82 @@ hawk@~3.1.3:
     cryptiles "2.x.x"
     hoek "2.x.x"
     sntp "1.x.x"
+
+heroku-cli-addons@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/heroku-cli-addons/-/heroku-cli-addons-1.1.3.tgz#ce948413306d78053fceed1c5dc1e0d260c92761"
+  dependencies:
+    co "4.6.0"
+    heroku-cli-util "6.0.15"
+    lodash.flatten "4.3.0"
+    lodash.groupby "4.5.1"
+    lodash.memoize "4.1.1"
+    lodash.merge "4.5.1"
+    lodash.some "4.5.1"
+    lodash.sortby "4.6.1"
+    lodash.topairs "4.2.0"
+    lodash.values "4.2.0"
+    printf "0.2.5"
+
+heroku-cli-addons@1.2.19:
+  version "1.2.19"
+  resolved "https://registry.yarnpkg.com/heroku-cli-addons/-/heroku-cli-addons-1.2.19.tgz#d19c09baa9c729ff3fcbc9e7516cf87a201428f8"
+  dependencies:
+    co "4.6.0"
+    co-wait "0.0.0"
+    heroku-cli-util "6.1.17"
+    lodash.flatten "4.4.0"
+    lodash.groupby "4.6.0"
+    lodash.memoize "4.1.2"
+    lodash.merge "4.6.0"
+    lodash.some "4.6.0"
+    lodash.sortby "4.7.0"
+    lodash.topairs "4.3.0"
+    lodash.values "4.3.0"
+    printf "0.2.5"
+
+heroku-cli-addons@1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/heroku-cli-addons/-/heroku-cli-addons-1.2.7.tgz#08a9a3cce2bd3697aad4cb4258c82c0df88fdfd2"
+  dependencies:
+    co "4.6.0"
+    co-wait "0.0.0"
+    heroku-cli-util "6.1.4"
+    lodash.flatten "4.4.0"
+    lodash.groupby "4.6.0"
+    lodash.memoize "4.1.2"
+    lodash.merge "4.6.0"
+    lodash.some "4.6.0"
+    lodash.sortby "4.7.0"
+    lodash.topairs "4.3.0"
+    lodash.values "4.3.0"
+    printf "0.2.5"
+
+heroku-cli-util@6.0.15:
+  version "6.0.15"
+  resolved "https://registry.yarnpkg.com/heroku-cli-util/-/heroku-cli-util-6.0.15.tgz#f1418c6bacab1cab8065eca035722094a82fd7d5"
+  dependencies:
+    ansi-escapes "1.4.0"
+    cardinal "^0.7.1"
+    chalk "^1.1.3"
+    co "4.6.0"
+    got "^6.3.0"
+    heroku-client "3.0.0-beta3"
+    lodash.ary "4.1.0"
+    lodash.defaults "4.1.0"
+    lodash.get "4.4.0"
+    lodash.identity "3.0.0"
+    lodash.keys "4.0.8"
+    lodash.mapvalues "4.5.0"
+    lodash.noop "3.0.1"
+    lodash.partial "4.2.0"
+    lodash.pickby "4.5.0"
+    lodash.property "4.4.0"
+    lodash.repeat "4.0.4"
+    lodash.result "4.5.0"
+    opn "^3.0.3"
+    supports-color "^3.1.2"
+    tunnel-agent "^0.4.3"
 
 heroku-cli-util@6.0.7:
   version "6.0.7"
@@ -1566,10 +1770,51 @@ heroku-cli-util@6.1.17:
     supports-color "^3.1.2"
     tunnel-agent "^0.4.3"
 
+heroku-cli-util@6.1.4:
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/heroku-cli-util/-/heroku-cli-util-6.1.4.tgz#4bc98647c5d80370aae189b16b016d69b6ec4d32"
+  dependencies:
+    ansi-escapes "1.4.0"
+    cardinal "1.0.0"
+    chalk "^1.1.3"
+    co "4.6.0"
+    got "^6.3.0"
+    heroku-client "3.0.1"
+    lodash.ary "4.1.1"
+    lodash.defaults "4.2.0"
+    lodash.get "4.4.2"
+    lodash.identity "3.0.0"
+    lodash.keys "4.2.0"
+    lodash.mapvalues "4.6.0"
+    lodash.noop "3.0.1"
+    lodash.partial "4.2.1"
+    lodash.pickby "4.6.0"
+    lodash.property "4.4.2"
+    lodash.repeat "4.1.0"
+    lodash.result "4.5.2"
+    opn "^3.0.3"
+    supports-color "^3.1.2"
+    tunnel-agent "^0.4.3"
+
 heroku-client@3.0.0-beta2:
   version "3.0.0-beta2"
   resolved "https://registry.yarnpkg.com/heroku-client/-/heroku-client-3.0.0-beta2.tgz#4ef5577187edf67c5577bee5bf48738da3e7327d"
   dependencies:
+    is-retry-allowed "^1.0.0"
+    tunnel-agent "^0.4.0"
+
+heroku-client@3.0.0-beta3:
+  version "3.0.0-beta3"
+  resolved "https://registry.yarnpkg.com/heroku-client/-/heroku-client-3.0.0-beta3.tgz#ab6e789be4284ee8188da7bafd19b6cd2c94c27a"
+  dependencies:
+    is-retry-allowed "^1.0.0"
+    tunnel-agent "^0.4.0"
+
+heroku-client@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/heroku-client/-/heroku-client-3.0.1.tgz#9c6a3c54ceeb805b45c3833926bf8ef0d1fb7ca5"
+  dependencies:
+    debug "^2.2.0"
     is-retry-allowed "^1.0.0"
     tunnel-agent "^0.4.0"
 
@@ -1626,6 +1871,55 @@ heroku-hello-world-build@0.0.0:
   dependencies:
     bindings "~1.2.1"
 
+heroku-kafka@2.9.8:
+  version "2.9.8"
+  resolved "https://registry.yarnpkg.com/heroku-kafka/-/heroku-kafka-2.9.8.tgz#dd60491b3b8b138f22c88a9f6720ce99ef3c50b0"
+  dependencies:
+    co "4.6.0"
+    co-wait "0.0.0"
+    debug "2.6.8"
+    heroku-cli-addons "1.2.19"
+    heroku-cli-util "6.1.17"
+    humanize-plus "^1.8.2"
+    lodash.uniqby "4.7.0"
+    no-kafka "github:hunterloftis/kafka"
+    node-spinner "0.0.4"
+
+heroku-pg-extras@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/heroku-pg-extras/-/heroku-pg-extras-1.0.11.tgz#c0ab6ca3e7296faaecc604cf937468a6795419e5"
+  dependencies:
+    co "4.6.0"
+    debug "2.2.0"
+    execa "0.4.0"
+    heroku-cli-addons "1.1.3"
+    heroku-cli-util "6.0.15"
+    heroku-pg "2.0.16"
+    lodash "4.15.0"
+    pg "6.1.0"
+
+heroku-pg@2.0.16:
+  version "2.0.16"
+  resolved "https://registry.yarnpkg.com/heroku-pg/-/heroku-pg-2.0.16.tgz#572bfac1b7e0cd7b6b820044271f48fe01d88189"
+  dependencies:
+    bytes "2.4.0"
+    co "4.6.0"
+    co-wait "0.0.0"
+    debug "2.6.0"
+    filesize "3.5.4"
+    heroku-cli-addons "1.2.7"
+    heroku-cli-util "6.1.4"
+    lodash.capitalize "4.2.1"
+    lodash.flatten "4.4.0"
+    lodash.sample "4.2.1"
+    lodash.sortby "4.7.0"
+    lodash.uniqby "4.7.0"
+    mkdirp "0.5.1"
+    smooth-progress "1.1.0"
+    string "3.3.3"
+    strip-eof "1.0.0"
+    tunnel-ssh "4.1.1"
+
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
@@ -1663,6 +1957,10 @@ http-signature@~1.1.0:
     assert-plus "^0.2.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
+
+humanize-plus@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/humanize-plus/-/humanize-plus-1.8.2.tgz#a65b34459ad6367adbb3707a82a3c9f916167030"
 
 iconv-lite@0.4.13:
   version "0.4.13"
@@ -2399,6 +2697,10 @@ lodash.ary@4.0.1:
   dependencies:
     lodash._createwrapper "~4.0.0"
 
+lodash.ary@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.ary/-/lodash.ary-4.1.0.tgz#db8eacd6d975af219ef4710b9eb2af00dddab048"
+
 lodash.ary@4.1.1, lodash.ary@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.ary/-/lodash.ary-4.1.1.tgz#66065fa91bacc7a034d9c8fce52f83d3c7e40212"
@@ -2411,6 +2713,10 @@ lodash.assigninwith@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assigninwith/-/lodash.assigninwith-4.2.0.tgz#af02c98432ac86d93da695b4be801401971736af"
 
+lodash.capitalize@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz#f826c9b4e2a8511d84e3aca29db05e1a4f3b72a9"
+
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
@@ -2422,11 +2728,19 @@ lodash.defaults@4.0.1:
     lodash.assigninwith "^4.0.0"
     lodash.rest "^4.0.0"
 
-lodash.defaults@4.2.0, lodash.defaults@^4.2.0:
+lodash.defaults@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.1.0.tgz#71e648b4d11de5202a4aa19c73c8c15bfa2cfee7"
+
+lodash.defaults@4.2.0, lodash.defaults@^4.1.0, lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
 
-lodash.flatten@4.x:
+lodash.flatten@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.3.0.tgz#e5ec4efe87efc59ce52f917cba8bf160636469cf"
+
+lodash.flatten@4.4.0, lodash.flatten@4.x:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
 
@@ -2436,9 +2750,21 @@ lodash.get@4.3.0:
   dependencies:
     lodash._stringtopath "~4.8.0"
 
+lodash.get@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.0.tgz#ed35fb9fe4681abc7eee8c2651120d9015d40a86"
+
 lodash.get@4.4.2, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
+lodash.groupby@4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.5.1.tgz#e614d82eb121388dfc8f60fd245b593cbb46abf7"
+
+lodash.groupby@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
 
 lodash.identity@3.0.0, lodash.identity@^3.0.0:
   version "3.0.0"
@@ -2447,6 +2773,10 @@ lodash.identity@3.0.0, lodash.identity@^3.0.0:
 lodash.keys@4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.0.7.tgz#30e1b3bd98e54d6a0611991812685b6bc47cb63b"
+
+lodash.keys@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.0.8.tgz#c0cf45d2fcf576c83055404d674c7e637c83ae81"
 
 lodash.keys@4.2.0, lodash.keys@^4.0.0, lodash.keys@^4.2.0:
   version "4.2.0"
@@ -2464,6 +2794,10 @@ lodash.mapvalues@4.4.0:
     lodash._baseiteratee "~4.7.0"
     lodash.keys "^4.0.0"
 
+lodash.mapvalues@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.5.0.tgz#5614f62b327a55882dfe0546bdd3f34ba8463873"
+
 lodash.mapvalues@4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
@@ -2472,7 +2806,19 @@ lodash.maxby@4.x:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.maxby/-/lodash.maxby-4.6.0.tgz#082240068f3c7a227aa00a8380e4f38cf0786e3d"
 
-lodash.merge@4.x:
+lodash.memoize@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.1.tgz#1f5a26e0560c7eed6140c4f4fb56be248456c8a1"
+
+lodash.memoize@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+
+lodash.merge@4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.5.1.tgz#15b8d95a1692568323b7a4e3d60d50a04f51f4eb"
+
+lodash.merge@4.6.0, lodash.merge@4.x:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
@@ -2487,6 +2833,10 @@ lodash.partial@4.1.4:
     lodash._createwrapper "~4.0.0"
     lodash.rest "^4.0.0"
 
+lodash.partial@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.partial/-/lodash.partial-4.2.0.tgz#833af6613ba0f296ccf2c4a1996cd20fce10ffcb"
+
 lodash.partial@4.2.1, lodash.partial@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash.partial/-/lodash.partial-4.2.1.tgz#49f3d8cfdaa3bff8b3a91d127e923245418961d4"
@@ -2498,6 +2848,10 @@ lodash.pickby@4.4.0:
     lodash._baseiteratee "~4.7.0"
     lodash.keysin "^4.0.0"
 
+lodash.pickby@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.5.0.tgz#463cedff6144f4c5b01cd97ed516b8f229802c02"
+
 lodash.pickby@4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
@@ -2508,6 +2862,10 @@ lodash.property@4.3.0:
   dependencies:
     lodash._stringtopath "~4.8.0"
 
+lodash.property@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.property/-/lodash.property-4.4.0.tgz#c897e51787bae041a1425cae330eaf4493513877"
+
 lodash.property@4.4.2, lodash.property@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.property/-/lodash.property-4.4.2.tgz#da07124821c6409d025f30db8df851314515bffe"
@@ -2517,6 +2875,10 @@ lodash.repeat@4.0.3:
   resolved "https://registry.yarnpkg.com/lodash.repeat/-/lodash.repeat-4.0.3.tgz#257389f4d6ac2925870a4a59480ff647281e8273"
   dependencies:
     lodash.tostring "^4.0.0"
+
+lodash.repeat@4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.repeat/-/lodash.repeat-4.0.4.tgz#096849227f31a3d4dec8db479f0c9828c07052a9"
 
 lodash.repeat@4.1.0:
   version "4.1.0"
@@ -2532,19 +2894,63 @@ lodash.result@4.4.0:
   dependencies:
     lodash._stringtopath "~4.8.0"
 
+lodash.result@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.result/-/lodash.result-4.5.0.tgz#8e9c07d3dd0a13f195f29d8bd8a64d4dd26a4321"
+
 lodash.result@4.5.2, lodash.result@^4.5.2:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.result/-/lodash.result-4.5.2.tgz#cb45b27fb914eaa8d8ee6f0ce7b2870b87cb70aa"
+
+lodash.sample@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.sample/-/lodash.sample-4.2.1.tgz#5e4291b0c753fa1abeb0aab8fb29df1b66f07f6d"
+
+lodash.some@4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.5.1.tgz#0778bba36fa0af71443d338a4f99651397ce0ac5"
+
+lodash.some@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
+
+lodash.sortby@4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.6.1.tgz#d957dc76b3994b2288ff2086d58e6e3e115dbf6f"
+
+lodash.sortby@4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+
+lodash.topairs@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.topairs/-/lodash.topairs-4.2.0.tgz#8488c0257e898ba9904a0965aef0b13d4a1a1933"
+
+lodash.topairs@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.topairs/-/lodash.topairs-4.3.0.tgz#3b6deaa37d60fb116713c46c5f17ea190ec48d64"
 
 lodash.tostring@^4.0.0:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/lodash.tostring/-/lodash.tostring-4.1.4.tgz#560c27d1f8eadde03c2cce198fef5c031d8298fb"
 
-lodash.uniqby@4.x:
+lodash.uniqby@4.7.0, lodash.uniqby@4.x:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.2:
+lodash.values@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.2.0.tgz#932625f7d2c954b63db895255548f3b49f120e9a"
+
+lodash.values@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
+
+lodash@4.15.0:
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.15.0.tgz#3162391d8f0140aa22cf8f6b3c34d6b7f63d3aa9"
+
+lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0, lodash@~4.17.2:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2553,6 +2959,10 @@ log-chopper@1.0.0:
   resolved "https://registry.yarnpkg.com/log-chopper/-/log-chopper-1.0.0.tgz#0f2a4cbf25b237395acb3480a54f8c5bd3f58190"
   dependencies:
     byline "5.x"
+
+long@^3.0.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -2567,6 +2977,13 @@ loose-envify@^1.0.0:
 lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
+
+lru-cache@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -2643,7 +3060,7 @@ minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-mkdirp@0.5, mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5, mkdirp@0.5.1, mkdirp@0.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -2661,6 +3078,10 @@ ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
+ms@0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -2673,9 +3094,9 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.3.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+nan@2.3.5, nan@^2.3.0:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.3.5.tgz#822a0dc266290ce4cd3a12282ca3e7e364668a08"
 
 natives@^1.1.0:
   version "1.1.0"
@@ -2697,6 +3118,25 @@ netrc-parser@2.0.2:
   dependencies:
     lex "^1.7.9"
 
+nice-simple-logger@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nice-simple-logger/-/nice-simple-logger-1.0.1.tgz#0f9e648527be7be3e49ab76fa8c8c098af951bf6"
+  dependencies:
+    lodash "^4.3.0"
+
+"no-kafka@github:hunterloftis/kafka":
+  version "2.4.1"
+  resolved "https://codeload.github.com/hunterloftis/kafka/tar.gz/755673c26086b3e5b9d46c0d96255b0d15fbf00f"
+  dependencies:
+    bin-protocol "^3.0.0"
+    bluebird "^3.3.3"
+    buffer-crc32 "^0.2.5"
+    hashring "^3.2.0"
+    lodash "^4.5.0"
+    nice-simple-logger "^1.0.1"
+    snappy "^5.0.0"
+    wrr-pool "^1.0.3"
+
 nock@9.0.13:
   version "9.0.13"
   resolved "https://registry.yarnpkg.com/nock/-/nock-9.0.13.tgz#d0bc39ef43d3179981e22b2e8ea069f916c5781a"
@@ -2709,6 +3149,25 @@ nock@9.0.13:
     mkdirp "^0.5.0"
     propagate "0.4.0"
     qs "^6.0.2"
+
+node-gyp@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.4.0.tgz#dda558393b3ecbbe24c9e6b8703c71194c63fa36"
+  dependencies:
+    fstream "^1.0.0"
+    glob "^7.0.3"
+    graceful-fs "^4.1.2"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.0"
+    nopt "2 || 3"
+    npmlog "0 || 1 || 2 || 3"
+    osenv "0"
+    path-array "^1.0.0"
+    request "2"
+    rimraf "2"
+    semver "2.x || 3.x || 4 || 5"
+    tar "^2.0.0"
+    which "1"
 
 node-gyp@3.x:
   version "3.6.2"
@@ -2755,6 +3214,12 @@ node-pre-gyp@^0.6.29:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
+node-spinner@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/node-spinner/-/node-spinner-0.0.4.tgz#4c5dad762f953bdcae74ec000f6cea054ef20c8e"
+  dependencies:
+    util-extend "~1.0.1"
+
 "nopt@2 || 3":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -2783,6 +3248,21 @@ normalize-path@^2.0.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+npm-run-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-1.0.0.tgz#f5c32bf595fe81ae927daec52e82f8b000ac3c8f"
+  dependencies:
+    path-key "^1.0.0"
+
+"npmlog@0 || 1 || 2 || 3":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-3.1.2.tgz#2d46fa874337af9498a2f12bb43d8d0be4a36873"
+  dependencies:
+    are-we-there-yet "~1.1.2"
+    console-control-strings "~1.1.0"
+    gauge "~2.6.0"
+    set-blocking "~2.0.0"
+
 "npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.2:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.0.tgz#dc59bee85f64f00ed424efb2af0783df25d1c0b5"
@@ -2803,6 +3283,10 @@ number-is-nan@^1.0.0:
 oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+
+object-assign@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
@@ -2910,6 +3394,10 @@ p-timeout@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-1.1.1.tgz#d28e9fdf96e328886fbff078f886ad158c53bf6d"
 
+packet-reader@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/packet-reader/-/packet-reader-0.2.0.tgz#819df4d010b82d5ea5671f8a1a3acf039bcd7700"
+
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
@@ -2929,6 +3417,12 @@ parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
 
+path-array@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-array/-/path-array-1.0.1.tgz#7e2f0f35f07a2015122b868b7eac0eb2c4fec271"
+  dependencies:
+    array-index "^1.0.0"
+
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
@@ -2946,6 +3440,10 @@ path-is-absolute@^1.0.0:
 path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-key@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-1.0.0.tgz#5d53d578019646c0d68800db4e146e6bdc2ac7af"
 
 path-parse@^1.0.5:
   version "1.0.5"
@@ -2968,6 +3466,45 @@ path-type@^2.0.0:
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
+
+pg-connection-string@0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-0.1.3.tgz#da1847b20940e42ee1492beaf65d49d91b245df7"
+
+pg-pool@1.*:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-1.8.0.tgz#f7ec73824c37a03f076f51bfdf70e340147c4f37"
+  dependencies:
+    generic-pool "2.4.3"
+    object-assign "4.1.0"
+
+pg-types@1.*:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-1.12.0.tgz#8ad3b7b897e3fd463e62de241ad5fc640b4a66f0"
+  dependencies:
+    ap "~0.2.0"
+    postgres-array "~1.0.0"
+    postgres-bytea "~1.0.0"
+    postgres-date "~1.0.0"
+    postgres-interval "^1.1.0"
+
+pg@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/pg/-/pg-6.1.0.tgz#4ebc58100a79187b6b98fa5caf1675d669926b41"
+  dependencies:
+    buffer-writer "1.0.1"
+    packet-reader "0.2.0"
+    pg-connection-string "0.1.3"
+    pg-pool "1.*"
+    pg-types "1.*"
+    pgpass "1.x"
+    semver "4.3.2"
+
+pgpass@1.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pgpass/-/pgpass-1.0.2.tgz#2a7bb41b6065b67907e91da1b07c1847c877b306"
+  dependencies:
+    split "^1.0.0"
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -2993,6 +3530,24 @@ pluralize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-4.0.0.tgz#59b708c1c0190a2f692f1c7618c446b052fd1762"
 
+postgres-array@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-1.0.2.tgz#8e0b32eb03bf77a5c0a7851e0441c169a256a238"
+
+postgres-bytea@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postgres-bytea/-/postgres-bytea-1.0.0.tgz#027b533c0aa890e26d172d47cf9ccecc521acd35"
+
+postgres-date@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/postgres-date/-/postgres-date-1.0.3.tgz#e2d89702efdb258ff9d9cee0fe91bd06975257a8"
+
+postgres-interval@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/postgres-interval/-/postgres-interval-1.1.0.tgz#1031e7bac34564132862adc9eb6c6d2f3aa75bb4"
+  dependencies:
+    xtend "^4.0.0"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -3012,6 +3567,10 @@ pretty-format@^20.0.3:
     ansi-regex "^2.1.1"
     ansi-styles "^3.0.0"
 
+printf@0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/printf/-/printf-0.2.5.tgz#c438ca2ca33e3927671db4ab69c0e52f936a4f0f"
+
 private@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
@@ -3028,6 +3587,10 @@ propagate@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.4.0.tgz#f3fcca0a6fe06736a7ba572966069617c130b481"
 
+protocol-buffers-schema@^3.0.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.3.1.tgz#ad151141877c6af8828647851af66a0db69275f5"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -3037,6 +3600,10 @@ ps-node@0.x:
   resolved "https://registry.yarnpkg.com/ps-node/-/ps-node-0.1.6.tgz#9af67a99d7b1d0132e51a503099d38a8d2ace2c3"
   dependencies:
     table-parser "^0.1.3"
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 "pullstream@>= 0.4.1 < 1":
   version "0.4.1"
@@ -3301,9 +3868,13 @@ sax@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
 
-"semver@2 || 3 || 4 || 5", semver@5.3.0, semver@^5.1.0, semver@^5.3.0, semver@~5.3.0:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@5.3.0, semver@^5.1.0, semver@^5.3.0, semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.2.tgz#c7a07158a80bedd052355b770d82d6640f803be7"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -3325,6 +3896,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+simple-lru-cache@0.0.x:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz#d59cc3a193c1a5d0320f84ee732f6e4713e511dd"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -3338,6 +3913,21 @@ slice-ansi@0.0.4:
   resolved "https://registry.yarnpkg.com/slice-stream/-/slice-stream-1.0.0.tgz#5b33bd66f013b1a7f86460b03d463dec39ad3ea0"
   dependencies:
     readable-stream "~1.0.31"
+
+smooth-progress@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/smooth-progress/-/smooth-progress-1.1.0.tgz#a51d6dbc2b1c4635ac94bf4be89364d5ce91ce32"
+  dependencies:
+    ansi-escapes "1.4.0"
+    chalk "^1.1.1"
+
+snappy@^5.0.0:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/snappy/-/snappy-5.0.5.tgz#ec189323469546aedde43592f7808808fd073b45"
+  dependencies:
+    bindings "1.2.1"
+    nan "2.3.5"
+    node-gyp "3.4.0"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -3381,9 +3971,29 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
+split@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/split/-/split-1.0.0.tgz#c4395ce683abcd254bc28fe1dabb6e5c27dcffae"
+  dependencies:
+    through "2"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+ssh2-streams@~0.1.18:
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/ssh2-streams/-/ssh2-streams-0.1.19.tgz#f80ececc2de1a39e1aa64469851ec32bc96b83f9"
+  dependencies:
+    asn1 "~0.2.0"
+    semver "^5.1.0"
+    streamsearch "~0.1.2"
+
+ssh2@^0.5.2:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/ssh2/-/ssh2-0.5.5.tgz#c7781ecd2ece7304a253cf620fab5a5c22bb2235"
+  dependencies:
+    ssh2-streams "~0.1.18"
 
 sshpk@^1.7.0:
   version "1.13.0"
@@ -3399,6 +4009,10 @@ sshpk@^1.7.0:
     jodid25519 "^1.0.0"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+streamsearch@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
 
 string-length@^1.0.1:
   version "1.0.1"
@@ -3421,7 +4035,7 @@ string-width@^2.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^3.0.0"
 
-string@3.x:
+string@3.3.3, string@3.x:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/string/-/string-3.3.3.tgz#5ea211cd92d228e184294990a6cc97b366a77cb0"
 
@@ -3454,6 +4068,10 @@ strip-bom@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
   dependencies:
     is-utf8 "^0.2.0"
+
+strip-eof@1.0.0, strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -3562,7 +4180,7 @@ throat@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.0.0.tgz#e7c64c867cbb3845f10877642f7b60055b8ec0d6"
 
-through@^2.3.6, through@^2.3.8:
+through@2, through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -3615,6 +4233,14 @@ tunnel-agent@^0.6.0:
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
   dependencies:
     safe-buffer "^5.0.1"
+
+tunnel-ssh@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/tunnel-ssh/-/tunnel-ssh-4.1.1.tgz#5b6b251f14eedb14c6cddcb5a39013cbbbe32b38"
+  dependencies:
+    debug "2.2.0"
+    lodash.defaults "^4.1.0"
+    ssh2 "^0.5.2"
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
@@ -3688,6 +4314,10 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
+util-extend@~1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/util-extend/-/util-extend-1.0.3.tgz#a7c216d267545169637b3b6edc6ca9119e2ff93f"
+
 uuid@3.x, uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
@@ -3746,7 +4376,7 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@1, which@^1.2.11, which@^1.2.12:
+which@1, which@^1.2.11, which@^1.2.12, which@^1.2.8:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:
@@ -3802,6 +4432,12 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
+wrr-pool@^1.0.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/wrr-pool/-/wrr-pool-1.1.3.tgz#fdad22f2ea1f30363ffe5d781cf79497a77ff07e"
+  dependencies:
+    lodash "^4.0.1"
+
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
@@ -3813,6 +4449,10 @@ xml-name-validator@^2.0.1:
 y18n@^3.2.0, y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
 yargs-parser@^2.4.1:
   version "2.4.1"


### PR DESCRIPTION
@dickeyxxx could you review?  this adds back in the code from before + locking of `semver` to skirt around the issues with `heroku-pg-extras` and `heroku-kafka` (really it is an issue with `snappy` requiring an older version of `node-gyp`)