### PR TITLE
Wrap migrator in a lockfile

### DIFF
--- a/src/plugins/migrator.js
+++ b/src/plugins/migrator.js
@@ -6,6 +6,7 @@ import LinkedPlugins from './linked'
 import PluginCache from './cache'
 import path from 'path'
 import fs from 'fs-extra'
+import Lock from '../lock'
 
 const debug = require('debug')('cli-engine:migrator')
 
@@ -13,19 +14,33 @@ export default class {
   userPlugins: UserPlugins
   linkedPlugins: LinkedPlugins
   out: Output
+  lock: Lock
 
   constructor (out: Output) {
     let cache = new PluginCache(out)
     this.userPlugins = new UserPlugins({out, config: out.config, cache})
     this.linkedPlugins = new LinkedPlugins({out, config: out.config, cache})
     this.out = out
+    this.lock = new Lock(this.out)
   }
 
   async run () {
+    // short circuit quickly without having to aquire the writer lock
     if (fs.existsSync(this.userPlugins.userPluginsPJSONPath)) return
     if (!fs.existsSync(path.join(this.userPlugins.userPluginsDir, 'plugins.json'))) return
+
     let pljson = await this._readPluginsJSON()
     if (!pljson) return false
+
+    let downgrade = await this.lock.upgrade()
+    await this._run(pljson)
+    await downgrade()
+  }
+
+  async _run (pljson: any) {
+    // prevent two parallel migrations from happening in case of a race
+    if (fs.existsSync(this.userPlugins.userPluginsPJSONPath)) return
+
     debug('has existing plugins')
     this.out.action.start('Migrating Heroku CLI v5 plugins')
     debug('removing existing node_modules')


### PR DESCRIPTION
@dickeyxxx could you review?  since we no longer go through the install in Plugins we lose the locking around individual plugin migrations, so I am adding the lock back in, but am not worried about the cache clearing since it should not exist in the cache yet during migration