### PR TITLE
Remove proxy from yarn calls

### DIFF
--- a/src/plugins/yarn.js
+++ b/src/plugins/yarn.js
@@ -91,8 +91,7 @@ export default class Yarn {
     if (args.length !== 0) await this.checkForYarnLock()
     args = args.concat([
       '--non-interactive',
-      ...Yarn.extraOpts,
-      ...this.proxyArgs()
+      ...Yarn.extraOpts
     ])
     if (global.yarnCacheDir !== false) {
       let cacheDir = global.yarnCacheDir || path.join(this.config.cacheDir, 'yarn')
@@ -128,14 +127,5 @@ export default class Yarn {
     if (this.cwd && !fs.existsSync(path.join(this.cwd, 'yarn.lock'))) {
       await this.exec()
     }
-  }
-
-  proxyArgs (): string[] {
-    let args = []
-    let http = process.env.http_proxy || process.env.HTTP_PROXY
-    let https = process.env.https_proxy || process.env.HTTPS_PROXY
-    if (http) args.push(`--proxy=${http}`)
-    if (https) args.push(`--https-proxy=${https}`)
-    return args
   }
 }


### PR DESCRIPTION
This code doesn't support NO_PROXY. The bundled version of yarn will handle these envars for you *and* NO_PTOXY.